### PR TITLE
Add simple xdf loader executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ set(SOURCES
 )
 
 add_library(xdf ${SOURCES})
+add_executable(loadtest test.cpp)
+target_link_libraries(loadtest PRIVATE xdf)
 
 target_compile_features(xdf PUBLIC cxx_std_11)
 set_target_properties(xdf PROPERTIES OUTPUT_NAME xdf PUBLIC_HEADER xdf.h)

--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,16 @@
+#include "xdf.h"
+#include <iostream>
+
+int main(int argc, char** argv) {
+	if(argc < 2) {
+		std::cerr << "Usage: " << argv[0] << " filename\n";
+		return 1;
+	}
+	Xdf XDFdata;
+	XDFdata.load_xdf(argv[1]);
+	for(const auto& stream: XDFdata.streams) {
+		std::cout << "Stream: " << stream.info.name
+				  << ' ' << stream.info.channel_count << " channels "
+				  << stream.info.sample_count << " samples\n";
+	}
+}


### PR DESCRIPTION
This adds a short example that loads an xdf file and prints some statistics.