### PR TITLE
Update Branch "Master" to "Main" in cppcmake.yml

### DIFF
--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -6,7 +6,7 @@ on:
     - v*.*
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   build:


### PR DESCRIPTION
Master branch was earlier renamed to main. Updating cppcmake.yml to match.