### PR TITLE
Include cstdint

### DIFF
--- a/xdf.h
+++ b/xdf.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <map>
 #include <set>
+#include <cstdint>
 
 /*! \class Xdf
  *


### PR DESCRIPTION
This makes uint64_t and similar uint*_t types available.

Note:
I am using AUR on Archlinux to install libxdf and the compilation was failing, complaining that uint64_t was not an existing type. Adding the include solved the problem.

I am surprise that the code could compile without the corresponding header included but maybe some compiler include it by default ?