### PR TITLE
Fixed potentially uninitialized variable

### DIFF
--- a/xdf.cpp
+++ b/xdf.cpp
@@ -712,7 +712,7 @@ void Xdf::resample(int userSrate)
 //function of reading the length of each chunk
 uint64_t Xdf::readLength(std::ifstream &file)
 {
-    uint8_t bytes;
+    uint8_t bytes = 0;
     Xdf::readBin(file, &bytes);
     uint64_t length = 0;
 


### PR DESCRIPTION
In the case where the file has reached the end, readBin doesn't initialize the "bytes" variable. It therefore contains garbage values, which has a small chance of making the switch select another case than "default", leading to an infinite loop. This isn't just speculation, this has actually happened to me while compiling in Unreal 5.3. It is worth mentionning that the idiomatic way of checking whether or not the file has reached the end is to use file.eof() instead of relying on the fact that the variable isn't touched by "read".