### PR TITLE
timeseries that can handle strings

### DIFF
--- a/xdf.h
+++ b/xdf.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <set>
 #include <cstdint>
+#include <variant>
 
 /*! \class Xdf
  *
@@ -54,7 +55,7 @@ public:
     struct Stream
     {
         //! A 2D vector which stores the time series of a stream. Each row represents a channel.
-        std::vector<std::vector<float> > time_series;
+        std::vector<std::vector<std::variant<int, float, double, int64_t, std::string>>> time_series;
         std::vector<double> time_stamps; /*!< A vector to store time stamps. */
         std::string streamHeader;   /*!< Raw XML of stream header chunk. */
         std::string streamFooter;   /*!< Raw XML of stream footer chunk. */
@@ -174,7 +175,7 @@ public:
      *
      * \sa offsets
      */
-    void detrend();
+    //void detrend();
 
     /*!
      * \brief Delete the time stamps vectors when no longer needed to
@@ -312,6 +313,23 @@ private:
      * \return the read data
      */
     template<typename T> T readBin(std::istream& is, T* obj = nullptr);
+    
+    /*    
+    * \brief Template function to read data of any type and store it in the time_series container.
+    * \param file The input file stream to read the data from.
+    * \param time_series A reference to a 2D vector storing the time series data for each channel.
+    * \param channel_count The number of channels to read data for.
+    */
+    template<typename T> void readData(std::ifstream &file, std::vector<std::vector<T>> &time_series, int channel_count);
+    
+    /*!
+    * \brief Utility function to handle time stamp reading or deduction.
+    * \param file The input file stream from which the time stamp is read.
+    * \param lastTimestamp The last timestamp value to calculate the new timestamp if needed.
+    * \param samplingInterval The interval between samples, used for calculating the timestamp when necessary.
+    * \return The calculated or read timestamp.
+    */
+    double readTimestamp(std::ifstream &file, double &lastTimestamp, double samplingInterval)
 };
 
 #endif // XDF_H


### PR DESCRIPTION
This fix allows the libxdf package to support strings (issue # 19).  I also cleaned up "case 3" in the load_xdf file.  part is required to support strings, but a lot of it is just reducing repetitive code.

Note that string support requires C++17 for std::variant 